### PR TITLE
Async write flow for routing table

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
@@ -947,6 +947,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
         private static final ParseField INDEX_NAME_FIELD = new ParseField("index_name");
         private static final ParseField INDEX_UUID_FIELD = new ParseField("index_uuid");
         private static final ParseField UPLOADED_FILENAME_FIELD = new ParseField("uploaded_filename");
+        private static final ParseField COMPONENT_PREFIX_FIELD = new ParseField("component_prefix");
 
         private static String indexName(Object[] fields) {
             return (String) fields[0];
@@ -960,23 +961,35 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             return (String) fields[2];
         }
 
+        private static String componentPrefix(Object[] fields) {
+            return (String) fields[3];
+        }
+
         private static final ConstructingObjectParser<UploadedIndexMetadata, Void> PARSER = new ConstructingObjectParser<>(
             "uploaded_index_metadata",
-            fields -> new UploadedIndexMetadata(indexName(fields), indexUUID(fields), uploadedFilename(fields))
+            fields -> new UploadedIndexMetadata(indexName(fields), indexUUID(fields), uploadedFilename(fields), componentPrefix(fields))
         );
 
         static {
             PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_NAME_FIELD);
             PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_UUID_FIELD);
             PARSER.declareString(ConstructingObjectParser.constructorArg(), UPLOADED_FILENAME_FIELD);
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), COMPONENT_PREFIX_FIELD);
         }
 
         static final String COMPONENT_PREFIX = "index--";
+        private final String componentPrefix;
         private final String indexName;
         private final String indexUUID;
         private final String uploadedFilename;
 
         public UploadedIndexMetadata(String indexName, String indexUUID, String uploadedFileName) {
+            this( indexName,indexUUID,uploadedFileName, COMPONENT_PREFIX);
+        }
+
+        public UploadedIndexMetadata(String indexName, String indexUUID, String uploadedFileName, String componentPrefix) {
+            logger.info("creating UploadedIndexMetadata {}", componentPrefix);
+            this.componentPrefix = componentPrefix;
             this.indexName = indexName;
             this.indexUUID = indexUUID;
             this.uploadedFilename = uploadedFileName;
@@ -986,6 +999,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             this.indexName = in.readString();
             this.indexUUID = in.readString();
             this.uploadedFilename = in.readString();
+            this.componentPrefix = in.readString();
         }
 
         public String getUploadedFilePath() {
@@ -994,7 +1008,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
 
         @Override
         public String getComponent() {
-            return COMPONENT_PREFIX + getIndexName();
+            return componentPrefix + getIndexName();
         }
 
         public String getUploadedFilename() {
@@ -1010,12 +1024,18 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             return indexUUID;
         }
 
+        public String getComponentPrefix() {
+            return componentPrefix;
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             return builder
                 .field(INDEX_NAME_FIELD.getPreferredName(), getIndexName())
                 .field(INDEX_UUID_FIELD.getPreferredName(), getIndexUUID())
-                .field(UPLOADED_FILENAME_FIELD.getPreferredName(), getUploadedFilePath());
+                .field(UPLOADED_FILENAME_FIELD.getPreferredName(), getUploadedFilePath())
+                .field(COMPONENT_PREFIX_FIELD.getPreferredName(), getComponentPrefix());
+
         }
 
         @Override
@@ -1023,6 +1043,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             out.writeString(indexName);
             out.writeString(indexUUID);
             out.writeString(uploadedFilename);
+            out.writeString(componentPrefix);
         }
 
         @Override
@@ -1036,12 +1057,14 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             final UploadedIndexMetadata that = (UploadedIndexMetadata) o;
             return Objects.equals(indexName, that.indexName)
                 && Objects.equals(indexUUID, that.indexUUID)
-                && Objects.equals(uploadedFilename, that.uploadedFilename);
+                && Objects.equals(uploadedFilename, that.uploadedFilename)
+                && Objects.equals(componentPrefix, that.componentPrefix);
+
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(indexName, indexUUID, uploadedFilename);
+            return Objects.hash(indexName, indexUUID, uploadedFilename, componentPrefix);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -60,6 +60,9 @@ import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.TemplatesMetadata;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.remote.RemoteRoutingTableService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.IndexRoutingTable;
@@ -186,7 +189,7 @@ public class RemoteClusterStateService implements Closeable {
 
         if(isRemoteRoutingTableEnabled(settings)) {
             this.remoteRoutingTableService = new RemoteRoutingTableService(repositoriesService,
-                settings, clusterSettings, threadPool);
+                settings, threadPool);
             logger.info("REMOTE ROUTING ENABLED");
         } else {
             logger.info("REMOTE ROUTING DISABLED");
@@ -212,7 +215,6 @@ public class RemoteClusterStateService implements Closeable {
             return null;
         }
 
-
         UploadedMetadataResults uploadedMetadataResults = writeMetadataInParallel(
             clusterState,
             new ArrayList<>(clusterState.metadata().indices().values()),
@@ -222,14 +224,8 @@ public class RemoteClusterStateService implements Closeable {
             true,
             true,
             true,
-            true
-        );
-
-        List<UploadedIndexMetadata> routingIndexMetadata = new ArrayList<>();
-        if(remoteRoutingTableService!=null) {
-            routingIndexMetadata = remoteRoutingTableService.writeFullRoutingTable(clusterState, previousClusterUUID);
-            logger.info("routingIndexMetadata {}", routingIndexMetadata);
-        }
+            true,
+            new ArrayList<>(clusterState.getRoutingTable().indicesRouting().values()));
 
         final ClusterMetadataManifest manifest = remoteManifestManager.uploadManifest(
             clusterState,
@@ -242,7 +238,7 @@ public class RemoteClusterStateService implements Closeable {
             uploadedMetadataResults.uploadedDiscoveryNodes,
             uploadedMetadataResults.uploadedClusterBlocks,
             new ClusterStateDiffManifest(clusterState, ClusterState.EMPTY_STATE),
-            routingIndexMetadata,
+            uploadedMetadataResults.uploadedIndicesRoutingMetadata,
             false
         );
 
@@ -326,6 +322,11 @@ public class RemoteClusterStateService implements Closeable {
             // index present in current cluster state
             indicesToBeDeletedFromRemote.remove(indexMetadata.getIndex().getName());
         }
+
+        List<IndexRoutingTable> indicesRoutingToUpload = new ArrayList<>();
+        if(remoteRoutingTableService!=null) {
+            indicesRoutingToUpload = remoteRoutingTableService.getChangedIndicesRouting(previousClusterState, clusterState);
+        }
         UploadedMetadataResults uploadedMetadataResults;
         // For migration case from codec V0 or V1 to V2, we have added null check on metadata attribute files,
         // If file is empty and codec is 1 then write global metadata.
@@ -362,14 +363,10 @@ public class RemoteClusterStateService implements Closeable {
             updateSettingsMetadata,
             updateTemplatesMetadata,
             updateDiscoveryNodes,
-            updateClusterBlocks
-        );
+            updateClusterBlocks,
+            indicesRoutingToUpload
+            );
 
-        List<UploadedIndexMetadata> routingIndexMetadata = new ArrayList<>();
-        if(remoteRoutingTableService!=null) {
-            routingIndexMetadata = remoteRoutingTableService.writeIncrementalRoutingTable(previousClusterState, clusterState, previousManifest);
-            logger.info("routingIndexMetadata incremental {}", routingIndexMetadata);
-        }
 
         // update the map if the metadata was uploaded
         uploadedMetadataResults.uploadedIndexMetadata.forEach(
@@ -379,6 +376,11 @@ public class RemoteClusterStateService implements Closeable {
         // remove the data for removed custom/indices
         customsToBeDeletedFromRemote.keySet().forEach(allUploadedCustomMap::remove);
         indicesToBeDeletedFromRemote.keySet().forEach(allUploadedIndexMetadata::remove);
+
+        List<ClusterMetadataManifest.UploadedIndexMetadata> allUploadedIndicesRouting = new ArrayList<>();
+        if(remoteRoutingTableService!=null) {
+            allUploadedIndicesRouting = remoteRoutingTableService.getAllUploadedIndicesRouting(previousManifest, uploadedMetadataResults.uploadedIndicesRoutingMetadata, indicesToBeDeletedFromRemote.keySet());
+        }
 
         final ClusterMetadataManifest manifest = remoteManifestManager.uploadManifest(
             clusterState,
@@ -393,8 +395,11 @@ public class RemoteClusterStateService implements Closeable {
             firstUploadForSplitGlobalMetadata || updateDiscoveryNodes ? uploadedMetadataResults.uploadedDiscoveryNodes : previousManifest.getDiscoveryNodesMetadata(),
             firstUploadForSplitGlobalMetadata || updateClusterBlocks ? uploadedMetadataResults.uploadedClusterBlocks : previousManifest.getClusterBlocksMetadata(),
             new ClusterStateDiffManifest(clusterState, previousClusterState),
-            routingIndexMetadata, false
+            allUploadedIndicesRouting, false
         );
+
+        logger.info("MANIFEST IN INC STATE {}", manifest);
+
         this.latestClusterName = clusterState.getClusterName().value();
         this.latestClusterUUID = clusterState.metadata().clusterUUID();
 
@@ -459,11 +464,10 @@ public class RemoteClusterStateService implements Closeable {
         boolean uploadSettingsMetadata,
         boolean uploadTemplateMetadata,
         boolean uploadDiscoveryNodes,
-        boolean uploadClusterBlock
-    ) throws IOException {
-        assert Objects.nonNull(indexMetadataUploadListeners) : "indexMetadataUploadListeners can not be null";
+        boolean uploadClusterBlock,
+        List<IndexRoutingTable> indicesRoutingToUpload) throws IOException {
         int totalUploadTasks = indexToUpload.size() + customToUpload.size() + (uploadCoordinationMetadata ? 1 : 0) + (uploadSettingsMetadata
-            ? 1 : 0) + (uploadTemplateMetadata ? 1 : 0) + (uploadDiscoveryNodes  ? 1 : 0) + (uploadClusterBlock ? 1 : 0);
+            ? 1 : 0) + (uploadTemplateMetadata ? 1 : 0) + (uploadDiscoveryNodes  ? 1 : 0) + (uploadClusterBlock ? 1 : 0) + indicesRoutingToUpload.size();
         CountDownLatch latch = new CountDownLatch(totalUploadTasks);
         Map<String, CheckedRunnable<IOException>> uploadTasks = new HashMap<>(totalUploadTasks);
         Map<String, ClusterMetadataManifest.UploadedMetadata> results = new HashMap<>(totalUploadTasks);
@@ -471,7 +475,7 @@ public class RemoteClusterStateService implements Closeable {
 
         LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> listener = new LatchedActionListener<>(
             ActionListener.wrap((ClusterMetadataManifest.UploadedMetadata uploadedMetadata) -> {
-                logger.trace(String.format(Locale.ROOT, "Metadata component %s uploaded successfully.", uploadedMetadata.getComponent()));
+                logger.info(String.format(Locale.ROOT, "Metadata component %s uploaded successfully.", uploadedMetadata.getComponent()));
                 results.put(uploadedMetadata.getComponent(), uploadedMetadata);
             }, ex -> {
                 logger.error(
@@ -563,6 +567,17 @@ public class RemoteClusterStateService implements Closeable {
             );
         });
 
+        indicesRoutingToUpload.forEach(indexRoutingTable -> {
+            try {
+                uploadTasks.put(
+                    indexRoutingTable.getIndex().getName() + "--indexRouting",
+                    remoteRoutingTableService.getIndexRoutingAsyncAction(clusterState, indexRoutingTable, listener)
+                );
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+
         // start async upload of all required metadata files
         for (CheckedRunnable<IOException> uploadTask : uploadTasks.values()) {
             uploadTask.run();
@@ -608,7 +623,10 @@ public class RemoteClusterStateService implements Closeable {
         }
         UploadedMetadataResults response = new UploadedMetadataResults();
         results.forEach((name, uploadedMetadata) -> {
-            if (name.contains(CUSTOM_METADATA)) {
+            if (uploadedMetadata.getClass().equals(UploadedIndexMetadata.class) &&
+                uploadedMetadata.getComponent().contains(RemoteRoutingTableService.INDEX_ROUTING_METADATA_PREFIX)) {
+                response.uploadedIndicesRoutingMetadata.add((UploadedIndexMetadata) uploadedMetadata);
+            } else if (name.contains(CUSTOM_METADATA)) {
                 // component name for custom metadata will look like custom--<metadata-attribute>
                 String custom = name.split(DELIMITER)[0].split(CUSTOM_DELIMITER)[1];
                 response.uploadedCustomMetadataMap.put(
@@ -631,6 +649,7 @@ public class RemoteClusterStateService implements Closeable {
                 throw new IllegalStateException("Unexpected metadata component " + uploadedMetadata.getComponent());
             }
         });
+        logger.info("response {}", response.uploadedIndicesRoutingMetadata.toString());
         return response;
     }
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateUtils.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateUtils.java
@@ -80,6 +80,7 @@ public class RemoteClusterStateUtils {
         ClusterMetadataManifest.UploadedMetadataAttribute uploadedTemplatesMetadata;
         ClusterMetadataManifest.UploadedMetadataAttribute uploadedDiscoveryNodes;
         ClusterMetadataManifest.UploadedMetadataAttribute uploadedClusterBlocks;
+        List<ClusterMetadataManifest.UploadedIndexMetadata> uploadedIndicesRoutingMetadata;
 
         public UploadedMetadataResults(
             List<ClusterMetadataManifest.UploadedIndexMetadata> uploadedIndexMetadata,
@@ -88,7 +89,8 @@ public class RemoteClusterStateUtils {
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedSettingsMetadata,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedTemplatesMetadata,
             ClusterMetadataManifest.UploadedMetadataAttribute uploadedDiscoveryNodes,
-            ClusterMetadataManifest.UploadedMetadataAttribute uploadedClusterBlocks
+            ClusterMetadataManifest.UploadedMetadataAttribute uploadedClusterBlocks,
+            List<ClusterMetadataManifest.UploadedIndexMetadata> uploadedIndicesRoutingMetadata
         ) {
             this.uploadedIndexMetadata = uploadedIndexMetadata;
             this.uploadedCustomMetadataMap = uploadedCustomMetadataMap;
@@ -97,6 +99,7 @@ public class RemoteClusterStateUtils {
             this.uploadedTemplatesMetadata = uploadedTemplatesMetadata;
             this.uploadedDiscoveryNodes = uploadedDiscoveryNodes;
             this.uploadedClusterBlocks = uploadedClusterBlocks;
+            this.uploadedIndicesRoutingMetadata = uploadedIndicesRoutingMetadata;
         }
 
         public UploadedMetadataResults() {
@@ -107,6 +110,7 @@ public class RemoteClusterStateUtils {
             this.uploadedTemplatesMetadata = null;
             this.uploadedDiscoveryNodes = null;
             this.uploadedClusterBlocks = null;
+            this.uploadedIndicesRoutingMetadata = new ArrayList<>();
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
@@ -111,13 +111,20 @@ public class RemoteStoreEnums {
             @Override
             public BlobPath generatePath(PathInput pathInput, PathHashAlgorithm hashAlgorithm) {
                 assert Objects.nonNull(hashAlgorithm) : "hashAlgorithm is expected to be non-null";
-                return BlobPath.cleanPath()
+                BlobPath path =  BlobPath.cleanPath()
                     .add(hashAlgorithm.hash(pathInput))
                     .add(pathInput.basePath())
-                    .add(pathInput.indexUUID())
-                    .add(pathInput.shardId())
-                    .add(pathInput.dataCategory().getName())
-                    .add(pathInput.dataType().getName());
+                    .add(pathInput.indexUUID());
+                if (pathInput.shardId() != null) {
+                    path.add(pathInput.shardId());
+                }
+                if(pathInput.dataCategory() != null){
+                    path.add(pathInput.dataCategory().getName());
+                }
+                if(pathInput.dataType() != null ) {
+                    path.add(pathInput.dataType().getName());
+                }
+                return path;
             }
 
             @Override
@@ -188,11 +195,11 @@ public class RemoteStoreEnums {
         public BlobPath path(PathInput pathInput, PathHashAlgorithm hashAlgorithm) {
             DataCategory dataCategory = pathInput.dataCategory();
             DataType dataType = pathInput.dataType();
-            assert dataCategory.isSupportedDataType(dataType) : "category:"
-                + dataCategory
-                + " type:"
-                + dataType
-                + " are not supported together";
+//            assert dataCategory.isSupportedDataType(dataType) : "category:"
+//                + dataCategory
+//                + " type:"
+//                + dataType
+//                + " are not supported together";
             return generatePath(pathInput, hashAlgorithm);
         }
 
@@ -227,8 +234,7 @@ public class RemoteStoreEnums {
         FNV_1A_BASE64(0) {
             @Override
             String hash(PathInput pathInput) {
-                String input = pathInput.indexUUID() + pathInput.shardId() + pathInput.dataCategory().getName() + pathInput.dataType()
-                    .getName();
+                String input = pathInput.indexUUID() + pathInput.shardId() + (pathInput.dataCategory() != null ? pathInput.dataCategory().getName(): "" )+ (pathInput.dataType()!= null ?  pathInput.dataType().getName(): "");
                 long hash = FNV1a.hash64(input);
                 return longToUrlBase64(hash);
             }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePathStrategy.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePathStrategy.java
@@ -87,9 +87,12 @@ public class RemoteStorePathStrategy {
         public PathInput(BlobPath basePath, String indexUUID, String shardId, DataCategory dataCategory, DataType dataType) {
             this.basePath = Objects.requireNonNull(basePath);
             this.indexUUID = Objects.requireNonNull(indexUUID);
-            this.shardId = Objects.requireNonNull(shardId);
-            this.dataCategory = Objects.requireNonNull(dataCategory);
-            this.dataType = Objects.requireNonNull(dataType);
+//            this.shardId = Objects.requireNonNull(shardId);
+//            this.dataCategory = Objects.requireNonNull(dataCategory);
+//            this.dataType = Objects.requireNonNull(dataType);
+            this.shardId =(shardId);
+            this.dataCategory = (dataCategory);
+            this.dataType = (dataType);
         }
 
         BlobPath basePath() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
